### PR TITLE
Remove unnecessary fogblend option and enforce celestial angle for fog coloring

### DIFF
--- a/src/main/java/fi/dy/masa/justenoughdimensions/world/JEDWorldProperties.java
+++ b/src/main/java/fi/dy/masa/justenoughdimensions/world/JEDWorldProperties.java
@@ -83,7 +83,6 @@ public class JEDWorldProperties
     private Vec3d skyColor = null;
     private Vec3d sunColor = null;
 
-    private Float fogBlendRatio = null;
     private Float skyBlendRatio = null;
     private Float moonScale = null;
     private Float sunScale = null;
@@ -220,7 +219,6 @@ public class JEDWorldProperties
         if (JEDJsonUtils.hasString(obj, "SkyColor"))    { this.skyColor     = JEDStringUtils.hexStringToColor(JEDJsonUtils.getString(obj, "SkyColor")); }
         if (JEDJsonUtils.hasString(obj, "SunColor"))    { this.sunColor     = JEDStringUtils.hexStringToColor(JEDJsonUtils.getString(obj, "SunColor")); }
 
-        if (JEDJsonUtils.hasFloat(obj, "FogBlend"))     { this.fogBlendRatio    = JEDJsonUtils.getFloat(obj, "FogBlend"); }
         if (JEDJsonUtils.hasFloat(obj, "SkyBlend"))     { this.skyBlendRatio    = JEDJsonUtils.getFloat(obj, "SkyBlend"); }
 
         if (JEDJsonUtils.hasFloat(obj, "MoonScale"))    { this.moonScale        = JEDJsonUtils.getFloat(obj, "MoonScale"); }
@@ -350,7 +348,6 @@ public class JEDWorldProperties
         if (this.skyColor != null)          { obj.add("SkyColor",           new JsonPrimitive(JEDStringUtils.colorToHexString(this.skyColor))); }
         if (this.sunColor != null)          { obj.add("SunColor",           new JsonPrimitive(JEDStringUtils.colorToHexString(this.sunColor))); }
 
-        if (this.fogBlendRatio != null)     { obj.add("FogBlend",           new JsonPrimitive(this.fogBlendRatio)); }
         if (this.skyBlendRatio != null)     { obj.add("SkyBlend",           new JsonPrimitive(this.skyBlendRatio)); }
 
         if (this.moonScale != null)         { obj.add("MoonScale",          new JsonPrimitive(this.moonScale)); }
@@ -526,12 +523,6 @@ public class JEDWorldProperties
     public Vec3d getCloudColor()
     {
         return this.cloudColor;
-    }
-
-    @Nullable
-    public Float getFogBlendRatio()
-    {
-        return this.fogBlendRatio;
     }
 
     @Nullable

--- a/src/main/java/fi/dy/masa/justenoughdimensions/world/WorldProviderJED.java
+++ b/src/main/java/fi/dy/masa/justenoughdimensions/world/WorldProviderJED.java
@@ -631,13 +631,6 @@ public class WorldProviderJED extends WorldProviderSurface implements IWorldProv
         float celestialAngleRadians = MathHelper.cos(celestialAngle * ((float) Math.PI * 2F)) * 2.0F + 0.5F;
         celestialAngleRadians = MathHelper.clamp(celestialAngleRadians, 0.0F, 1.0F);
 
-        Float fogBlend = this.properties.getFogBlendRatio();
-        float blendRatio = fogBlend != null ? MathHelper.clamp(fogBlend.floatValue(), 0.0f, 1.0f) : 0.0f;
-
-        float r = (float) fogColor.x * (celestialAngleRadians * 0.94F + 0.06F) * (1.0f - blendRatio) + (float) fogColor.x * blendRatio;
-        float g = (float) fogColor.y * (celestialAngleRadians * 0.94F + 0.06F) * (1.0f - blendRatio) + (float) fogColor.y * blendRatio;
-        float b = (float) fogColor.z * (celestialAngleRadians * 0.91F + 0.09F) * (1.0f - blendRatio) + (float) fogColor.z * blendRatio;
-
-        return new Vec3d(r, g, b);
+        return fogColor.scale(celestialAngleRadians);
     }
 }


### PR DESCRIPTION
The custom fog color doesn't use the celestial angle like it's supposed to.  This results in the night sky having fog color that never changes from it's day color.  The fog color should darken with the night like it does in vanilla.  To do otherwise looks really bad and unnatural.  If a constant sky/fog color is desired it is recommended to make a world with no day cycle.

Removed fogBlend as it isn't necessary since one can simply not override fog if the default slightly bluish tinted fog is desired.  This allows the fog color to be the value that is expected.  fogBlend also adds a complication since users will not even see the difference anyway.